### PR TITLE
Switch to using MiddlewareMixin for Django 1.10

### DIFF
--- a/zesty_metrics/middleware.py
+++ b/zesty_metrics/middleware.py
@@ -7,6 +7,7 @@ from hashlib import md5
 
 from django.core.cache import cache
 from django.db import IntegrityError
+from django.utils.deprecation import MiddlewareMixin
 
 from user_agents import parse as parse_ua
 import statsd
@@ -52,7 +53,7 @@ class LocalStatsd(threading.local):
             self.pipeline = client
 
 
-class MetricsMiddleware(object):
+class MetricsMiddleware(MiddlewareMixin):
     """Middleware to capture basic metrics about a request.
 
     Includes:

--- a/zesty_metrics/middleware.py
+++ b/zesty_metrics/middleware.py
@@ -7,7 +7,11 @@ from hashlib import md5
 
 from django.core.cache import cache
 from django.db import IntegrityError
-from django.utils.deprecation import MiddlewareMixin
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    class MiddlewareMixin:
+        pass
 
 from user_agents import parse as parse_ua
 import statsd

--- a/zesty_metrics/middleware.py
+++ b/zesty_metrics/middleware.py
@@ -10,7 +10,7 @@ from django.db import IntegrityError
 try:
     from django.utils.deprecation import MiddlewareMixin
 except ImportError:
-    class MiddlewareMixin:
+    class MiddlewareMixin(object):
         pass
 
 from user_agents import parse as parse_ua


### PR DESCRIPTION
This allows us to continue using this library in Django 1.9 and older.

https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware